### PR TITLE
fix: Colocar en comentario el go init

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -50,7 +50,7 @@ steps:
 - name: go_build
   image: golang:1.14
   commands:
-  - go mod init
+  #- go mod init
   - go get -t
   - GOOS=linux GOARCH=amd64 go build -o main
   when:


### PR DESCRIPTION
Se coloco en comentario el go mod init para que no haya conflicto en crearse archivos de drone